### PR TITLE
Correct how CocoaPods is written in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EmojiBuilder
 
-A Swift script that is one part Emoji unicode parser, and one part code generator. The result of which is now a [CocoaPods](https://github.com/skyefreeman/EmojiConstants).
+A Swift script that is one part Emoji unicode parser, and one part code generator. The result of which is now a [CocoaPod](https://github.com/skyefreeman/EmojiConstants).
 A full write up of how it operates is in the works.
 
 Credit for the hexadecimal value ranges:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EmojiBuilder
 
-A Swift script that is one part Emoji unicode parser, and one part code generator. The result of which is now a [cocoapod](https://github.com/skyefreeman/EmojiConstants).
+A Swift script that is one part Emoji unicode parser, and one part code generator. The result of which is now a [CocoaPods](https://github.com/skyefreeman/EmojiConstants).
 A full write up of how it operates is in the works.
 
 Credit for the hexadecimal value ranges:


### PR DESCRIPTION
See https://github.com/CocoaPods/shared_resources/tree/master/media :)

Created with [`readme-correct`](https://github.com/dkhamsing/readme-correct).
